### PR TITLE
add routes as constants

### DIFF
--- a/src/components/TopNavigation.vue
+++ b/src/components/TopNavigation.vue
@@ -75,7 +75,7 @@
 <script>
 import * as cons from '@/constants.js';
 import { mapActions, mapGetters } from 'vuex';
-console.log(cons);
+
 export default {
   computed: {
     ...mapGetters({

--- a/src/components/portfolio/Stock.vue
+++ b/src/components/portfolio/Stock.vue
@@ -58,7 +58,6 @@ export default {
       placeSellOrder: 'sellStock'
     }),
     sellThisStock() {
-      console.log(this.stock);
       const order = {
         stockId: this.id,
         stockPrice: this.price,

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -1,3 +1,4 @@
+import * as cons from '../../src/constants';
 import { localVue, setRouter, stringSearcher } from '../Factory';
 import App from '@/App';
 import { mount } from '@vue/test-utils';
@@ -23,13 +24,13 @@ describe('MainApp.vue', () => {
     expect(wrapper.text().match('Trade or View your Portfolio').length).toBe(1);
   });
   it('should change the pages with router', async () => {
-    router.push('/portfolio');
+    router.push(cons.PORTFOLIO_ROUTE);
     await wrapper.vm.$nextTick();
     expect((wrapper.text().match('Please buy some stocks') || []).length).toBe(1);
-    router.push('/analysis');
+    router.push(cons.ANALYSIS_ROUTE);
     await wrapper.vm.$nextTick();
     expect((wrapper.text().match('End the current day. Please select a stock from the stock tab') || []).length).toBe(1);
-    router.push('/stocks');
+    router.push(cons.STOCKS_ROUTE);
     await wrapper.vm.$nextTick();
     expect(wrapper.text()).toMatchSnapshot();
   });
@@ -56,7 +57,7 @@ describe('MainApp.vue', () => {
     await wrapper.vm.$nextTick();
     expect(firstStock.find('.form-control').text()).toBe('');
 
-    router.push('/portfolio');
+    router.push(cons.PORTFOLIO_ROUTE);
     await wrapper.vm.$nextTick();
 
     expect(stringSearcher(wrapper,
@@ -77,7 +78,7 @@ describe('MainApp.vue', () => {
   });
   it('should not ask the user to select a stock', async () => {
     // TODO: see the reason for the test cross contamination
-    router.push('/analysis');
+    router.push(cons.ANALYSIS_ROUTE);
     await wrapper.vm.$nextTick();
     expect((wrapper.text().match('Please select a stock fr') || []).length).toBe(0);
   });


### PR DESCRIPTION
In larger projects we have a problem when these paths are used in a lot of places and we want to change the path. Without constants we are suddenly in a problem. We would need to track down all the instances where the path is used and change it. Now we can change it in one place.